### PR TITLE
Add example of how to run CronJob using secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,39 @@ once its done, push it to your image repository, or rename and push to a local r
 
 1. Create secret.txt with the exports from the section above (include the export command).
 
-2. Create a configmap for the txt file
-`kubectl create configmap git-token --from-file=secret.txt`
+2. Create a configmap or a secret with the needed variables.
 
-3. Deploy either a pod or a CronJob (see manifests folder).
+configmap:
+
+`kubectl create configmap github2jira-secret --from-file=secret.txt`  
+Where secret.txt is a file in the format (see section above)
+```
+export JIRA_SERVER=<..>
+```
+
+secret:
+
+Create a secret in the format:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github2jira-secret
+type: Opaque
+data:
+  # list of all the env vars in the format:
+  # ENV_VAR_NAME:BASE64_VALUE
+```
+
+Note:
+In order to ease base64 encoding you can use the following command  
+`cat secret.in | awk -F= '{printf("  "$1": "); system("echo -n " $2"| base64")}'`  
+where `secret.in` is a list of `NAME=VALUE`, one per line.  
+Empty lines are not allowed.  
+The character `=` is not allowed as part of the VALUE.
+
+It will print the data section that you can use as part of your secret.
+
+3. Deploy either a pod or a CronJob (see [manifests](manifests) folder).  
+There are two types of CronJobs, one for configmap and one for secret.
+

--- a/manifests/cronjob_secret.yaml
+++ b/manifests/cronjob_secret.yaml
@@ -18,15 +18,9 @@ spec:
                 - /bin/sh
                 - -ce
                 - |
-                  source /app/secret.txt
                   git clone https://github.com/oshoval/github2jira.git
                   ./github2jira/main.py
-              volumeMounts:
-                - name: configs
-                  mountPath: /app/secret.txt
-                  subPath: secret.txt
+              envFrom:
+                - secretRef:
+                    name: github2jira-secret
           restartPolicy: Never
-          volumes:
-            - name: configs
-              configMap:
-                name: github2jira-secret

--- a/manifests/gitpod.yaml
+++ b/manifests/gitpod.yaml
@@ -19,4 +19,4 @@ spec:
   volumes:
     - name: configs
       configMap:
-        name: git-token
+        name: github2jira-secret


### PR DESCRIPTION
Suggest a method to use secret instead of a configmap for k8s payloads.

Secrets by default are only base64 encoded,
but in case there is encryption on RBAC or encryption on secrets, and not on configmaps,
it will be safer to use secrets instead of configmaps.

Moreover it will serve as a tip for a non malicious admin to not mess with the information.

Signed-off-by: Or Shoval <oshoval@redhat.com>